### PR TITLE
Additional mixing tests and fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ Color.prototype = {
    mix: function(mixinColor, weight) {
       var color1 = this;
       var color2 = mixinColor;
-      var weight = weight || 50;
+      var weight = weight !== undefined ? weight : 50;
 
       var p = weight / 100;
       var w = 2 * p - 1;

--- a/test/index.js
+++ b/test/index.js
@@ -182,6 +182,19 @@ it('Mix: alpha', function() {
   equal(Color("rgba(255, 0, 0, 0.5)").mix(Color("#00f")).rgbaString(), 'rgba(64, 0, 191, 0.75)');
 });
 
+it('Mix: 50%', function() {
+  equal(Color("#f00").mix(Color("#00f"), 50).hexString(), '#800080');
+});
+
+it('Mix: 0%', function() {
+  equal(Color("#f00").mix(Color("#00f"), 0).hexString(), '#0000FF');
+});
+
+it('Mix: 100%', function() {
+  equal(Color("#f00").mix(Color("#00f"), 100).hexString(), '#FF0000');
+});
+
+
 it('Clone', function() {
   var clone = Color({r: 10, g: 20, b: 30});
   deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);


### PR DESCRIPTION
Hi,

Thanks for writing this library. I have found it useful.

I came across an issue with the mixing logic when using 0% mix which I've attempted to fix in this pull request. I hope it looks ok.

I also found it confusing that the `mix` example in the README uses a fraction (0.3) but the function takes a percentage value (30). I can't really show that the example is wrong as I'm not sure what the initial `color` value is but I think it is misleading.

I also feel it would make more sense to use a fraction rather than a percentage. I also feel that a 1.0 or 100% value would more intuitively return the mix in color rather than the original color. My intuition might not be shared by everyone though :)

Anyway, hope some of that helps. Thanks again for the library,
Michael